### PR TITLE
Dockerize the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Minimal Python container
+FROM python:3.8-alpine
+
+# Copy files to container
+WORKDIR /app
+ADD . /app
+
+# Install dependencies
+RUN pip install -r requirements.txt
+
+# Port
+EXPOSE 5000
+
+# Start the application
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ Flask-SQLAlchemy==2.4.4
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-pkg-resources==0.0.0
 SQLAlchemy==1.3.20
 Werkzeug==1.0.1


### PR DESCRIPTION
# Dockerize the application
Resolves #4: **[Optional] Dockerize The Project**

## Modifications
- Remove `pkg-resources==0.0.0` from `requirements.txt`. Why? See [this](https://github.com/pypa/pip/issues/4022). It is a known bug in Ubuntu and `virtualenv`s and causes problems building the Docker image.
  ``` requirements.txt
    ...
  - pkg-resources==0.0.0
    ...
  ```
- Create the `Dockerfile` using `python:3.8-alpine` as the base.
  ``` Dockerfile
  # Minimal Python container
  FROM python:3.8-alpine
  ```
  The dependencies are installed via `requirements.txt` while building the image.

## Building
- Build the image using:
  ``` bash
  docker build -t secretpeek .
  ```
- The application runs on port 5000 by default. While executing `flask run`, the host needs to be explicitly passed as `0.0.0.0` to allow non-local access to the server.
  ``` Dockerfile
  ...
  # Start the application
  CMD ["flask", "run", "--host=0.0.0.0"]
  ```
  The image may simply be executed in a container, forwarding port 5000 to any desired port, say, 8080.
  ``` bash
  docker run --rm -p 8080:5000 secretpeek
  ```